### PR TITLE
Fixes #25 Fix docs script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist
 demo
 website
+scripts

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint --ext ts .",
     "build": "tsc",
     "dev": "npm run build && webpack -p && qode --inspect ./demo-dist/main.js",
-    "docs": "rm -rf ./website/docs/api && typedoc && rm ./website/docs/api/globals.md ./website/docs/api/index.md"
+    "docs": "npx run-func ./scripts/docs.js cleanApiDocs && typedoc && node ./scripts/docs.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const API_PATH = path.resolve(__dirname, '../website/docs/api');
+const SIDEBARS_FILE = path.resolve(__dirname, '../website/sidebars.js');
+const sidebarsData = require('../website/sidebars');
+
+['index.md', 'globals.md'].forEach((fileName) => {
+  if (fs.existsSync(`${API_PATH}/${fileName}`)) {
+    fs.unlinkSync(`${API_PATH}/${fileName}`);
+  }
+});
+
+if (sidebarsData.guides && sidebarsData.guides.Interfaces) {
+  const interfaces = sidebarsData.guides.Interfaces;
+  delete sidebarsData.guides.Interfaces;
+
+  if (sidebarsData.api) {
+    sidebarsData.api.Interfaces = interfaces;
+
+    if (sidebarsData.api.Widgets) {
+      delete sidebarsData.api.Widgets;
+    }
+  }
+
+  if (fs.existsSync(SIDEBARS_FILE)) {
+    const data = `module.exports = ${JSON.stringify(sidebarsData, null, 2)}`;
+    fs.writeFileSync(SIDEBARS_FILE, data);
+  }
+}
+
+function cleanApiDocs() {
+  if (fs.existsSync(API_PATH)) {
+    fs.rmdirSync(API_PATH, { recursive: true });
+  }
+}
+
+module.exports = { cleanApiDocs };

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -16,15 +16,11 @@ if (sidebarsData.guides && sidebarsData.guides.Interfaces) {
   delete sidebarsData.guides.Interfaces;
 
   if (sidebarsData.api) {
-    sidebarsData.api.Interfaces = interfaces;
-
-    if (sidebarsData.api.Widgets) {
-      delete sidebarsData.api.Widgets;
-    }
+    sidebarsData.api.Widgets = interfaces;
   }
 
   if (fs.existsSync(SIDEBARS_FILE)) {
-    const data = `module.exports = ${JSON.stringify(sidebarsData, null, 2)}`;
+    const data = `module.exports = ${JSON.stringify(sidebarsData, null, 2)};\n`;
     fs.writeFileSync(SIDEBARS_FILE, data);
   }
 }

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -8,10 +8,10 @@ module.exports = {
       "guides/5-handle-events",
       "guides/6-images",
       "guides/7-networking"
-    ],
+    ]
   },
   "api": {
-    "Widgets": [
+    "Interfaces": [
       "api/interfaces/buttonprops",
       "api/interfaces/checkboxprops",
       "api/interfaces/imageprops",
@@ -24,4 +24,4 @@ module.exports = {
       "api/interfaces/viewprops"
     ]
   }
-};
+}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -11,7 +11,7 @@ module.exports = {
     ]
   },
   "api": {
-    "Interfaces": [
+    "Widgets": [
       "api/interfaces/buttonprops",
       "api/interfaces/checkboxprops",
       "api/interfaces/imageprops",
@@ -24,4 +24,4 @@ module.exports = {
       "api/interfaces/viewprops"
     ]
   }
-}
+};


### PR DESCRIPTION
Fixes #25 
Create a new script that handles all things docs related:
- Used node's `rmdirSync` instead of `rm -rf` in order to have better cross-platform support
- Move the generated array from `guides.Interfaces` to `api.Interfaces`
- Delete `api.Widgets` array